### PR TITLE
Allow specifying namespace for longhorn grafana dashboard

### DIFF
--- a/charts/longhorn-monitoring/Chart.yaml
+++ b/charts/longhorn-monitoring/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: longhorn-monitoring
 description: Monitor longhorn storage driver
 type: application
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.1.0
+appVersion: 1.1.0
 icon: https://raw.githubusercontent.com/SomeBlackMagic/helm-charts/master/charts/longhorn-monitoring/longhorn-prometheus-grafana.png
 keywords:
   - longhorn

--- a/charts/longhorn-monitoring/templates/grafana/configmap-dashboard.yaml
+++ b/charts/longhorn-monitoring/templates/grafana/configmap-dashboard.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-%s" (include "longhorn-monitoring.fullname" $) $dashboardName | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $.Values.grafana.namespace | default $.Release.Namespace }}
   labels:
     {{- include "longhorn-monitoring.labels" $ | nindent 4 }}
     {{- if $.Values.grafana.defaultLabel }}

--- a/charts/longhorn-monitoring/values.yaml
+++ b/charts/longhorn-monitoring/values.yaml
@@ -11,7 +11,6 @@ serviceMonitor:
   # service monitors configured.
   # namespace: ""
 
-
 prometheus:
   # -- Create prometheus-operator resources
   enabled: true
@@ -55,7 +54,7 @@ prometheus:
     #     severity: critical
 
 grafana:
-  # -- Enable deploying cert-manager dashboard to Grafana
+  # -- Enable deploying longhorn dashboard to Grafana
   enabled: false
   # -- Add `grafana_dashboard: "1"` default label
   defaultLabel: true
@@ -63,3 +62,5 @@ grafana:
   extraLabels: {}
   # -- Extra annotations for dashboard ConfigMap
   extraAnnotations: {}
+  # -- Optional Namespace for Grafana dashboard
+  namespace: ""


### PR DESCRIPTION
Currently the grafana dashboard for longhorn is locked to the namespace of the release, this allows the user to change that.